### PR TITLE
chore: Update prebuild versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1531,9 +1531,9 @@
 			"dev": true
 		},
 		"node-abi": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-			"integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
+			"version": "2.19.3",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+			"integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
 			"requires": {
 				"semver": "^5.4.1"
 			}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"install": "prebuild-install || npm run patch:win && node-gyp rebuild",
 		"test": "mocha test/iota_common.js",
 		"rebuild": "prebuild --compile",
-		"prebuild-node": "prebuild -t 8.12.0 -t 9.4.0 -t 10.11.0 -t 12.14.0 --strip",
-		"prebuild-electron": "prebuild -t 4.2.3 -t 6.1.5 -t 8.2.1 -r electron --strip",
+		"prebuild-node": "prebuild -t 10.11.0 -t 12.14.0 --strip",
+		"prebuild-electron": "prebuild -t 8.2.1 -r electron --strip",
 		"prebuild": "npm run prebuild-node && npm run prebuild-electron && node ./src/upload.js",
 		"clang-format": "clang-format -style=file -fallback-style=none -i src/interface.cpp"
 	},

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"devDependencies": {
 		"chai": "^4.2.0",
 		"mocha": "^8.2.0",
-		"node-abi": "^2.15.0",
+		"node-abi": "^2.19.3",
 		"prebuild": "^10.0.0"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"test": "mocha test/iota_common.js",
 		"rebuild": "prebuild --compile",
 		"prebuild-node": "prebuild -t 10.23.0 -t 12.20.0 -t 14.15.3 --strip",
-		"prebuild-electron": "prebuild -t 8.5.5 -t 9.4.0 -r electron --strip",
+		"prebuild-electron": "prebuild -t 7.3.3 -t 8.5.5 -t 9.4.0 -r electron --strip",
 		"prebuild": "npm run prebuild-node && npm run prebuild-electron && node ./src/upload.js",
 		"clang-format": "clang-format -style=file -fallback-style=none -i src/interface.cpp"
 	},

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"install": "prebuild-install || npm run patch:win && node-gyp rebuild",
 		"test": "mocha test/iota_common.js",
 		"rebuild": "prebuild --compile",
-		"prebuild-node": "prebuild -t 10.11.0 -t 12.14.0 --strip",
-		"prebuild-electron": "prebuild -t 8.2.1 -r electron --strip",
+		"prebuild-node": "prebuild -t 10.23.0 -t 12.20.0 -t 14.15.3 --strip",
+		"prebuild-electron": "prebuild -t 8.5.5 -t 9.4.0 -r electron --strip",
 		"prebuild": "npm run prebuild-node && npm run prebuild-electron && node ./src/upload.js",
 		"clang-format": "clang-format -style=file -fallback-style=none -i src/interface.cpp"
 	},


### PR DESCRIPTION
- Drop prebuild support for older/EOL node and electron versions
- Add prebuilds for latest versions of node and electron
- Add prebuild for current Trinity electron version